### PR TITLE
Check requirements and dependencies for repos

### DIFF
--- a/src/zcl_abapgit_ci_distributor.clas.abap
+++ b/src/zcl_abapgit_ci_distributor.clas.abap
@@ -123,15 +123,17 @@ CLASS zcl_abapgit_ci_distributor IMPLEMENTATION.
 
     DATA(lo_repo) = get_repo( ).
 
-    DATA(ls_checks) = lo_repo->deserialize_checks( ).
-
-    LOOP AT ls_checks-overwrite ASSIGNING FIELD-SYMBOL(<ls_overwrite>).
-      <ls_overwrite>-decision = abap_true.
-    ENDLOOP.
+    TRY.
+        DATA(ls_checks) = zcl_abapgit_ci_repo_check=>get( lo_repo ).
+      CATCH zcx_abapgit_cancel INTO DATA(lx_cancel).
+        zcx_abapgit_exception=>raise(
+          iv_text     = lx_cancel->get_text( )
+          ix_previous = lx_cancel ).
+    ENDTRY.
 
     lo_repo->deserialize(
-        is_checks = ls_checks
-        ii_log    = NEW zcl_abapgit_log( ) ).
+      is_checks = ls_checks
+      ii_log    = NEW zcl_abapgit_log( ) ).
 
     save_results_in_mime_repo( is_result ).
 

--- a/src/zcl_abapgit_ci_repo_check.clas.abap
+++ b/src/zcl_abapgit_ci_repo_check.clas.abap
@@ -1,0 +1,49 @@
+CLASS zcl_abapgit_ci_repo_check DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS get
+      IMPORTING
+        !io_repo         TYPE REF TO zcl_abapgit_repo_online
+      RETURNING
+        VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
+      RAISING
+        zcx_abapgit_cancel
+        zcx_abapgit_exception .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_ci_repo_check IMPLEMENTATION.
+
+
+  METHOD get.
+
+    rs_checks = io_repo->deserialize_checks( ).
+
+    " Auto-confirm all decisions
+    LOOP AT rs_checks-overwrite ASSIGNING FIELD-SYMBOL(<ls_overwrite>).
+      <ls_overwrite>-decision = zif_abapgit_definitions=>gc_yes.
+    ENDLOOP.
+
+    LOOP AT rs_checks-warning_package ASSIGNING FIELD-SYMBOL(<ls_warning_package>).
+      <ls_warning_package>-decision = zif_abapgit_definitions=>gc_yes.
+    ENDLOOP.
+
+    " If requirements are not met, cancel process
+    IF rs_checks-requirements-met <> zif_abapgit_definitions=>gc_yes.
+      zcx_abapgit_cancel=>raise( 'Requirements not met' ).
+    ENDIF.
+
+    " If dependencies are not met, cancel process
+    IF rs_checks-dependencies-met <> zif_abapgit_definitions=>gc_yes.
+      zcx_abapgit_cancel=>raise( 'Dependencies not met' ).
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_abapgit_ci_repo_check.clas.xml
+++ b/src/zcl_abapgit_ci_repo_check.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_CI_REPO_CHECK</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit CI: Repo check logic</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_abapgit_ci_repos.clas.abap
+++ b/src/zcl_abapgit_ci_repos.clas.abap
@@ -193,6 +193,7 @@ CLASS zcl_abapgit_ci_repos IMPLEMENTATION.
 
       IF <repo>->get_name( ) = iv_repo_name.
         lo_repo ?= <repo>.
+        EXIT.
       ENDIF.
 
     ENDLOOP.
@@ -203,15 +204,17 @@ CLASS zcl_abapgit_ci_repos IMPLEMENTATION.
 
     lo_repo->select_branch( 'refs/heads/main' ).
 
-    DATA(ls_checks) = lo_repo->deserialize_checks( ).
-
-    LOOP AT ls_checks-overwrite ASSIGNING FIELD-SYMBOL(<ls_overwrite>).
-      <ls_overwrite>-decision = abap_true.
-    ENDLOOP.
+    TRY.
+        DATA(ls_checks) = zcl_abapgit_ci_repo_check=>get( lo_repo ).
+      CATCH zcx_abapgit_cancel INTO DATA(lx_cancel).
+        zcx_abapgit_exception=>raise(
+          iv_text     = lx_cancel->get_text( )
+          ix_previous = lx_cancel ).
+    ENDTRY.
 
     lo_repo->deserialize(
-        is_checks = ls_checks
-        ii_log    = NEW zcl_abapgit_log( ) ).
+      is_checks = ls_checks
+      ii_log    = NEW zcl_abapgit_log( ) ).
 
     syntax_check( lo_repo->get_package( ) ).
 


### PR DESCRIPTION
- Check minimum requirements of software components for repos
- Check dependencies for repos

If either check fails during pull, the remaining steps will not be executed and you can a corresponding error message.

Does this close #8 or should we suppress the error and set the status to "ok"? 

![image](https://user-images.githubusercontent.com/59966492/119844524-cb83fb00-bf08-11eb-9414-eb96e4187c38.png)

PS: Of course, we need to go through the test repos and update the release requirements where necessary in order for this to work properly. So far, I did it only for `FTGL`. 