### PR TITLE
Adjust output

### DIFF
--- a/src/zcl_abapgit_ci_alv_view.clas.abap
+++ b/src/zcl_abapgit_ci_alv_view.clas.abap
@@ -6,63 +6,69 @@ CLASS zcl_abapgit_ci_alv_view DEFINITION
 
     INTERFACES zif_abapgit_ci_view .
   PROTECTED SECTION.
-  PRIVATE SECTION.
-    METHODS:
-      prepare_splitter
-        EXPORTING
-          eo_row_1 TYPE REF TO cl_gui_container
-          eo_row_2 TYPE REF TO cl_gui_container
-          eo_row_3 TYPE REF TO cl_gui_container
-          eo_row_4 TYPE REF TO cl_gui_container
-        RAISING
-          zcx_abapgit_exception,
+private section.
 
-      prepare_header
-        IMPORTING
-          iv_text      TYPE string
-          io_container TYPE REF TO cl_gui_container
-        RAISING
-          zcx_abapgit_exception,
-
-      display_alv
-        CHANGING
-          cs_result TYPE zif_abapgit_ci_definitions=>ty_result
-        RAISING
-          zcx_abapgit_exception,
-
-      display_list
-        CHANGING
-          cs_result TYPE zif_abapgit_ci_definitions=>ty_result
-        RAISING
-          zcx_abapgit_exception.
-
+  methods PREPARE_SPLITTER
+    importing
+      !IV_GEN type ABAP_BOOL
+      !IV_REPO type ABAP_BOOL
+    exporting
+      !EO_ROW_1 type ref to CL_GUI_CONTAINER
+      !EO_ROW_2 type ref to CL_GUI_CONTAINER
+      !EO_ROW_3 type ref to CL_GUI_CONTAINER
+      !EO_ROW_4 type ref to CL_GUI_CONTAINER
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods PREPARE_HEADER
+    importing
+      !IV_TEXT type STRING
+      !IO_CONTAINER type ref to CL_GUI_CONTAINER
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods DISPLAY_ALV
+    changing
+      !CS_RESULT type ZIF_ABAPGIT_CI_DEFINITIONS=>TY_RESULT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods DISPLAY_LIST
+    changing
+      !CS_RESULT type ZIF_ABAPGIT_CI_DEFINITIONS=>TY_RESULT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_ci_alv_view IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_CI_ALV_VIEW IMPLEMENTATION.
 
 
   METHOD display_alv.
 
     prepare_splitter(
+      EXPORTING
+        iv_gen   = xsdbool( cs_result-generic_result_list IS NOT INITIAL )
+        iv_repo  = xsdbool( cs_result-repo_result_list IS NOT INITIAL )
       IMPORTING
         eo_row_1 = DATA(lo_row_1)
         eo_row_2 = DATA(lo_row_2)
         eo_row_3 = DATA(lo_row_3)
         eo_row_4 = DATA(lo_row_4) ).
 
-    prepare_header( iv_text      = |abapGit CI - Generic Tests|
-                    io_container = lo_row_1 ).
+    IF cs_result-generic_result_list IS NOT INITIAL.
+      prepare_header( iv_text      = |abapGit CI - Generic Tests|
+                      io_container = lo_row_1 ).
 
-    NEW lcl_alv( io_container = lo_row_2
-                 it_table     = cs_result-generic_result_list )->display( ).
+      NEW lcl_alv( io_container = lo_row_2
+                   it_table     = cs_result-generic_result_list )->display( ).
+    ENDIF.
 
-    prepare_header( iv_text      = |abapGit CI - Repository Tests from https://github.com/abapGit-tests|
-                    io_container = lo_row_3 ).
+    IF cs_result-repo_result_list IS NOT INITIAL.
+      prepare_header( iv_text      = |abapGit CI - Repository Tests from https://github.com/abapGit-tests|
+                      io_container = lo_row_3 ).
 
-    NEW lcl_alv( io_container = lo_row_4
-                 it_table     = cs_result-repo_result_list )->display( ).
+      NEW lcl_alv( io_container = lo_row_4
+                   it_table     = cs_result-repo_result_list )->display( ).
+    ENDIF.
 
     WRITE: ''.
 
@@ -181,7 +187,7 @@ CLASS zcl_abapgit_ci_alv_view IMPLEMENTATION.
     lo_splitter->set_row_height(
       EXPORTING
         id                = 1
-        height            = 5
+        height            = COND #( WHEN iv_gen = abap_true THEN 6 ELSE 0 )
       EXCEPTIONS
         cntl_error        = 1
         cntl_system_error = 2
@@ -205,17 +211,19 @@ CLASS zcl_abapgit_ci_alv_view IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    lo_splitter->set_row_height(
-      EXPORTING
-        id                = 2
-        height            = 20
-      EXCEPTIONS
-        cntl_error        = 1
-        cntl_system_error = 2
-        OTHERS            = 3 ).
+    IF iv_repo = abap_true.
+      lo_splitter->set_row_height(
+        EXPORTING
+          id                = 2
+          height            = COND #( WHEN iv_gen = abap_true THEN 10 ELSE 0 )
+        EXCEPTIONS
+          cntl_error        = 1
+          cntl_system_error = 2
+          OTHERS            = 3 ).
 
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise_t100( ).
+      ENDIF.
     ENDIF.
 
     lo_splitter->set_row_sash(
@@ -235,7 +243,7 @@ CLASS zcl_abapgit_ci_alv_view IMPLEMENTATION.
     lo_splitter->set_row_height(
       EXPORTING
         id                = 3
-        height            = 5
+        height            = COND #( WHEN iv_repo = abap_true THEN 6 ELSE 0 )
       EXCEPTIONS
         cntl_error        = 1
         cntl_system_error = 2
@@ -259,17 +267,19 @@ CLASS zcl_abapgit_ci_alv_view IMPLEMENTATION.
       zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
-    lo_splitter->set_row_height(
-      EXPORTING
-        id                = 4
-        height            = 40
-      EXCEPTIONS
-        cntl_error        = 1
-        cntl_system_error = 2
-        OTHERS            = 3 ).
+    IF iv_gen = abap_true.
+      lo_splitter->set_row_height(
+        EXPORTING
+          id                = 4
+          height            = COND #( WHEN iv_repo = abap_true THEN 40 ELSE 0 )
+        EXCEPTIONS
+          cntl_error        = 1
+          cntl_system_error = 2
+          OTHERS            = 3 ).
 
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise_t100( ).
+      ENDIF.
     ENDIF.
 
   ENDMETHOD.

--- a/src/zcl_abapgit_ci_alv_view.clas.abap
+++ b/src/zcl_abapgit_ci_alv_view.clas.abap
@@ -6,35 +6,35 @@ CLASS zcl_abapgit_ci_alv_view DEFINITION
 
     INTERFACES zif_abapgit_ci_view .
   PROTECTED SECTION.
-private section.
+  PRIVATE SECTION.
 
-  methods PREPARE_SPLITTER
-    importing
-      !IV_GEN type ABAP_BOOL
-      !IV_REPO type ABAP_BOOL
-    exporting
-      !EO_ROW_1 type ref to CL_GUI_CONTAINER
-      !EO_ROW_2 type ref to CL_GUI_CONTAINER
-      !EO_ROW_3 type ref to CL_GUI_CONTAINER
-      !EO_ROW_4 type ref to CL_GUI_CONTAINER
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods PREPARE_HEADER
-    importing
-      !IV_TEXT type STRING
-      !IO_CONTAINER type ref to CL_GUI_CONTAINER
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods DISPLAY_ALV
-    changing
-      !CS_RESULT type ZIF_ABAPGIT_CI_DEFINITIONS=>TY_RESULT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods DISPLAY_LIST
-    changing
-      !CS_RESULT type ZIF_ABAPGIT_CI_DEFINITIONS=>TY_RESULT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
+    METHODS prepare_splitter
+      IMPORTING
+        !iv_gen   TYPE abap_bool
+        !iv_repo  TYPE abap_bool
+      EXPORTING
+        !eo_row_1 TYPE REF TO cl_gui_container
+        !eo_row_2 TYPE REF TO cl_gui_container
+        !eo_row_3 TYPE REF TO cl_gui_container
+        !eo_row_4 TYPE REF TO cl_gui_container
+      RAISING
+        zcx_abapgit_exception .
+    METHODS prepare_header
+      IMPORTING
+        !iv_text      TYPE string
+        !io_container TYPE REF TO cl_gui_container
+      RAISING
+        zcx_abapgit_exception .
+    METHODS display_alv
+      CHANGING
+        !cs_result TYPE zif_abapgit_ci_definitions=>ty_result
+      RAISING
+        zcx_abapgit_exception .
+    METHODS display_list
+      CHANGING
+        !cs_result TYPE zif_abapgit_ci_definitions=>ty_result
+      RAISING
+        zcx_abapgit_exception .
 ENDCLASS.
 
 

--- a/src/zcl_abapgit_ci_alv_view.clas.locals_imp.abap
+++ b/src/zcl_abapgit_ci_alv_view.clas.locals_imp.abap
@@ -169,6 +169,8 @@ CLASS lcl_alv IMPLEMENTATION.
           CHANGING
             t_table      = <lt_table> ).
 
+        mo_alv->get_selections( )->set_selection_mode( if_salv_c_selection_mode=>row_column ).
+
         mo_alv->get_functions( )->set_all( ).
 
         LOOP AT mt_column_width ASSIGNING FIELD-SYMBOL(<ls_column_width>).


### PR DESCRIPTION
- Make individual cells in AVL grid selectable
- If generic or repo options is not selected, hide corresponding sections in output