### PR TITLE
Add option to save without push

### DIFF
--- a/src/zabapgit_ci.prog.abap
+++ b/src/zabapgit_ci.prog.abap
@@ -23,6 +23,7 @@ SELECTION-SCREEN COMMENT /1(79) opt03.
 SELECTION-SCREEN SKIP.
 PARAMETERS:
   p_url  TYPE string LOWER CASE,
+  p_save TYPE abap_bool AS CHECKBOX,
   p_hist TYPE abap_bool AS CHECKBOX.
 SELECTION-SCREEN END OF BLOCK b2.
 
@@ -136,6 +137,7 @@ CLASS lcl_abapgit_ci IMPLEMENTATION.
           ii_view          = NEW zcl_abapgit_ci_alv_view( )
           is_options       = VALUE #(
             result_git_repo_url    = p_url
+            save_without_push      = p_save
             save_to_history        = p_hist
             post_errors_to_slack   = slack
             slack_oauth_token      = token

--- a/src/zabapgit_ci.prog.xml
+++ b/src/zabapgit_ci.prog.xml
@@ -151,6 +151,12 @@
     </item>
     <item>
      <ID>S</ID>
+     <KEY>P_SAVE</KEY>
+     <ENTRY>Save results without push</ENTRY>
+     <LENGTH>33</LENGTH>
+    </item>
+    <item>
+     <ID>S</ID>
      <KEY>P_SYNC</KEY>
      <ENTRY>Synchronous processing</ENTRY>
      <LENGTH>30</LENGTH>

--- a/src/zcl_abapgit_ci_controller.clas.abap
+++ b/src/zcl_abapgit_ci_controller.clas.abap
@@ -143,6 +143,7 @@ CLASS ZCL_ABAPGIT_CI_CONTROLLER IMPLEMENTATION.
     IF ms_options-result_git_repo_url IS NOT INITIAL.
       NEW zcl_abapgit_ci_distributor(
         iv_url     = ms_options-result_git_repo_url
+        iv_save    = ms_options-save_without_push
         iv_history = ms_options-save_to_history )->push_to_git_repo( is_result = ls_result ).
     ENDIF.
 

--- a/src/zcl_abapgit_ci_distributor.clas.abap
+++ b/src/zcl_abapgit_ci_distributor.clas.abap
@@ -7,6 +7,7 @@ CLASS zcl_abapgit_ci_distributor DEFINITION
     METHODS constructor
       IMPORTING
         !iv_url     TYPE string
+        !iv_save    TYPE abap_bool DEFAULT abap_false
         !iv_history TYPE abap_bool DEFAULT abap_false
       RAISING
         zcx_abapgit_exception .
@@ -32,6 +33,7 @@ CLASS zcl_abapgit_ci_distributor DEFINITION
 
     DATA:
       mv_history TYPE abap_bool,
+      mv_save    TYPE abap_bool,
       mv_url     TYPE string.
 
     METHODS:
@@ -78,7 +80,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_CI_DISTRIBUTOR IMPLEMENTATION.
+CLASS zcl_abapgit_ci_distributor IMPLEMENTATION.
 
 
   METHOD add_file_to_mime_repo.
@@ -122,6 +124,7 @@ CLASS ZCL_ABAPGIT_CI_DISTRIBUTOR IMPLEMENTATION.
     ENDIF.
 
     mv_url = iv_url.
+    mv_save = iv_save.
     mv_history = iv_history.
 
   ENDMETHOD.
@@ -242,6 +245,11 @@ CLASS ZCL_ABAPGIT_CI_DISTRIBUTOR IMPLEMENTATION.
       ii_log    = NEW zcl_abapgit_log( ) ).
 
     save_results_in_mime_repo( is_result ).
+
+    " Save without pushing results to repo
+    IF mv_save = abap_true.
+      RETURN.
+    ENDIF.
 
     DATA(lo_stage) = stage( lo_repo ).
 

--- a/src/zif_abapgit_ci_definitions.intf.abap
+++ b/src/zif_abapgit_ci_definitions.intf.abap
@@ -43,6 +43,7 @@ INTERFACE zif_abapgit_ci_definitions
     BEGIN OF ty_options,
       result_git_repo_url    TYPE string,
       save_to_history        TYPE abap_bool,
+      save_without_push      TYPE abap_bool,
       post_errors_to_slack   TYPE abap_bool,
       slack_oauth_token      TYPE string,
       exec_generic_checks    TYPE abap_bool,


### PR DESCRIPTION
Allow saving the HTML and JSON output locally without updating the ci.abapgit.org repo