### PR TITLE
Add option to force release transports in clean-up

### DIFF
--- a/src/zabapgit_ci_cleanup.prog.xml
+++ b/src/zabapgit_ci_cleanup.prog.xml
@@ -31,6 +31,12 @@
     </item>
     <item>
      <ID>S</ID>
+     <KEY>P_FORCE</KEY>
+     <ENTRY>Force release (ignore errors)</ENTRY>
+     <LENGTH>37</LENGTH>
+    </item>
+    <item>
+     <ID>S</ID>
      <KEY>P_LIST</KEY>
      <ENTRY>Show all leftovers</ENTRY>
      <LENGTH>27</LENGTH>


### PR DESCRIPTION
Sometimes transports can't be released for example if objects have been deleted already or tadir entries are missing. The new option allows releasing such transports anyway.

![image](https://user-images.githubusercontent.com/59966492/161447752-7740d71a-1ee1-45f6-a8fc-0cc7b44ad42d.png)
