### PR TITLE
New feature: Logging of diffs / objects

### DIFF
--- a/src/zabapgit_ci_cleanup.prog.abap
+++ b/src/zabapgit_ci_cleanup.prog.abap
@@ -69,6 +69,7 @@ CLASS lcl_main DEFINITION.
       get_packages RETURNING VALUE(rt_devclass) TYPE ty_devc_tt,
       list_packages RAISING zcx_abapgit_exception,
       list_objects,
+      list_logs,
       list_otr.
 ENDCLASS.
 
@@ -102,6 +103,8 @@ CLASS lcl_main IMPLEMENTATION.
     list_objects( ).
 
     list_otr( ).
+
+    list_logs( ).
 
   ENDMETHOD.
 
@@ -179,6 +182,32 @@ CLASS lcl_main IMPLEMENTATION.
       LOOP AT lt_tadir INTO DATA(ls_tadir).
         FORMAT COLOR COL_NORMAL.
         WRITE: AT /5 ls_tadir-object, ls_tadir-obj_name, ls_tadir-delflag, ls_tadir-devclass, AT c_width space.
+        FORMAT COLOR OFF.
+      ENDLOOP.
+    ELSE.
+      FORMAT COLOR COL_POSITIVE.
+      WRITE: AT /5 'None', AT c_width space.
+    ENDIF.
+    SKIP.
+
+  ENDMETHOD.
+
+  METHOD list_logs.
+    DATA lt_logs TYPE STANDARD TABLE OF wwwdata WITH DEFAULT KEY.
+
+    SELECT * FROM wwwdata INTO TABLE @lt_logs
+      WHERE objid LIKE @zcl_abapgit_ci_log=>co_all
+      ORDER BY PRIMARY KEY.
+
+    FORMAT COLOR COL_KEY.
+    WRITE: / 'Logs:', AT c_count lines( lt_logs ), AT c_width space.
+    FORMAT COLOR OFF.
+    SKIP.
+
+    IF sy-subrc = 0.
+      LOOP AT lt_logs INTO DATA(ls_log).
+        FORMAT COLOR COL_NORMAL.
+        WRITE: AT /5 ls_log-objid, ls_log-text, AT c_width space.
         FORMAT COLOR OFF.
       ENDLOOP.
     ELSE.

--- a/src/zabapgit_ci_cleanup.prog.abap
+++ b/src/zabapgit_ci_cleanup.prog.abap
@@ -10,6 +10,7 @@ PARAMETERS: p_list  TYPE abap_bool RADIOBUTTON GROUP r2 DEFAULT 'X',
             p_remov TYPE abap_bool RADIOBUTTON GROUP r2,
             p_obj   TYPE abap_bool RADIOBUTTON GROUP r2,
             p_otr   TYPE abap_bool RADIOBUTTON GROUP r2,
+            p_log   TYPE abap_bool RADIOBUTTON GROUP r2,
             p_pack  TYPE abap_bool RADIOBUTTON GROUP r2.
 SELECTION-SCREEN END OF BLOCK b1.
 
@@ -32,6 +33,7 @@ CLASS lcl_main DEFINITION.
       drop_packages RAISING zcx_abapgit_exception,
       drop_objects RAISING zcx_abapgit_exception,
       drop_otr RAISING zcx_abapgit_exception,
+      drop_logs RAISING zcx_abapgit_exception,
       delete_package
         IMPORTING
           iv_package   TYPE devclass
@@ -81,6 +83,8 @@ CLASS lcl_main IMPLEMENTATION.
           drop_objects( ).
         ELSEIF p_otr = abap_true.
           drop_otr( ).
+        ELSEIF p_log = abap_true.
+          drop_logs( ).
         ELSEIF p_list = abap_true.
           list( ).
         ELSE.
@@ -190,7 +194,9 @@ CLASS lcl_main IMPLEMENTATION.
       lt_head  TYPE STANDARD TABLE OF sotr_head,
       lt_headu TYPE STANDARD TABLE OF sotr_headu,
       ls_use   TYPE sotr_use,
-      ls_useu  TYPE sotr_useu.
+      ls_useu  TYPE sotr_useu,
+      ls_text  TYPE sotr_text,
+      ls_textu TYPE sotr_textu.
 
     SELECT * FROM sotr_head INTO TABLE @lt_head WHERE paket IN @s_pack[]
       ORDER BY paket, concept.
@@ -203,12 +209,13 @@ CLASS lcl_main IMPLEMENTATION.
     IF sy-subrc = 0.
       LOOP AT lt_head INTO DATA(ls_head).
         FORMAT COLOR COL_NORMAL.
-        WRITE: AT /5 ls_head-concept, ls_head-paket.
-        SELECT SINGLE * FROM sotr_use INTO @ls_use WHERE concept = @ls_head-concept.
-        IF sy-subrc = 0.
-          WRITE: ls_use-object, ls_use-obj_name(70).
-        ENDIF.
-        WRITE AT c_width space.
+        WRITE: AT /5 ls_head-concept, ls_head-paket, AT c_width space.
+        SELECT * FROM sotr_use INTO @ls_use WHERE concept = @ls_head-concept ORDER BY PRIMARY KEY.
+          WRITE: AT /10 ls_use-object, ls_use-obj_name(70), AT c_width space.
+        ENDSELECT.
+        SELECT * FROM sotr_text INTO @ls_text WHERE concept = @ls_head-concept ORDER BY PRIMARY KEY.
+          WRITE: AT /10 ls_text-langu, ls_text-lfd_num, ls_text-text(120), AT c_width space.
+        ENDSELECT.
         FORMAT COLOR OFF.
       ENDLOOP.
     ELSE.
@@ -228,12 +235,13 @@ CLASS lcl_main IMPLEMENTATION.
     IF sy-subrc = 0.
       LOOP AT lt_headu INTO DATA(ls_headu).
         FORMAT COLOR COL_NORMAL.
-        WRITE: AT /5 ls_headu-concept, ls_headu-paket.
-        SELECT SINGLE * FROM sotr_useu INTO @ls_useu WHERE concept = @ls_headu-concept.
-        IF sy-subrc = 0.
-          WRITE: ls_useu-object, ls_useu-obj_name(70).
-        ENDIF.
-        WRITE AT c_width space.
+        WRITE: AT /5 ls_headu-concept, ls_headu-paket, AT c_width space.
+        SELECT * FROM sotr_useu INTO @ls_useu WHERE concept = @ls_headu-concept ORDER BY PRIMARY KEY.
+          WRITE: AT /10 ls_useu-object, ls_useu-obj_name(70), AT c_width space.
+        ENDSELECT.
+        SELECT * FROM sotr_textu INTO @ls_textu WHERE concept = @ls_headu-concept ORDER BY PRIMARY KEY.
+          WRITE: AT /10 ls_textu-langu, ls_textu-lfd_num, ls_textu-text(120), AT c_width space.
+        ENDSELECT.
         FORMAT COLOR OFF.
       ENDLOOP.
     ELSE.
@@ -525,6 +533,12 @@ CLASS lcl_main IMPLEMENTATION.
       ENDIF.
     ENDLOOP.
 
+  ENDMETHOD.
+
+  METHOD drop_logs.
+    DATA(lo_log) = NEW zcl_abapgit_ci_log( ).
+
+    lo_log->drop_all( ).
   ENDMETHOD.
 
   METHOD delete_package.

--- a/src/zabapgit_ci_cleanup.prog.abap
+++ b/src/zabapgit_ci_cleanup.prog.abap
@@ -568,6 +568,8 @@ CLASS lcl_main IMPLEMENTATION.
     DATA(lo_log) = NEW zcl_abapgit_ci_log( ).
 
     lo_log->drop_all( ).
+
+    list_logs( ).
   ENDMETHOD.
 
   METHOD delete_package.

--- a/src/zabapgit_ci_cleanup.prog.xml
+++ b/src/zabapgit_ci_cleanup.prog.xml
@@ -43,6 +43,12 @@
     </item>
     <item>
      <ID>S</ID>
+     <KEY>P_LOG</KEY>
+     <ENTRY>Remove logs</ENTRY>
+     <LENGTH>19</LENGTH>
+    </item>
+    <item>
+     <ID>S</ID>
      <KEY>P_OBJ</KEY>
      <ENTRY>Remove leftover objects</ENTRY>
      <LENGTH>31</LENGTH>

--- a/src/zcl_abapgit_ci_log.clas.abap
+++ b/src/zcl_abapgit_ci_log.clas.abap
@@ -1,0 +1,321 @@
+CLASS zcl_abapgit_ci_log DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    METHODS add
+      IMPORTING
+        !iv_log_object TYPE string
+        !is_data       TYPE any OPTIONAL
+        !it_data       TYPE ANY TABLE OPTIONAL
+      RETURNING
+        VALUE(rv_key)  TYPE string
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS drop_all
+      RAISING
+        zcx_abapgit_exception.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    TYPES:
+      ty_wwwparams_tt TYPE STANDARD TABLE OF wwwparams WITH DEFAULT KEY.
+
+    CONSTANTS:
+      co_package TYPE devclass VALUE '$TMP',
+      co_prefix  TYPE string VALUE 'ZABAPGIT_CI_',
+      BEGIN OF co_param_names,
+        version  TYPE w3_name VALUE 'version',
+        fileext  TYPE w3_name VALUE 'fileextension',
+        filesize TYPE w3_name VALUE 'filesize',
+        filename TYPE w3_name VALUE 'filename',
+        mimetype TYPE w3_name VALUE 'mimetype',
+      END OF co_param_names.
+
+    METHODS get_next_objid
+      RETURNING
+        VALUE(rv_objid) TYPE string.
+
+    METHODS set_params
+      IMPORTING
+        !is_key          TYPE wwwdatatab
+        !iv_size         TYPE i
+        !iv_name         TYPE string
+      RETURNING
+        VALUE(rt_params) TYPE ty_wwwparams_tt
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS stringify
+      IMPORTING
+        !ig_data         TYPE any
+      RETURNING
+        VALUE(rv_string) TYPE string
+      RAISING
+        zcx_abapgit_exception.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_ci_log IMPLEMENTATION.
+
+
+  METHOD add.
+
+    DATA:
+      lv_xstring  TYPE xstring,
+      lv_obj_name TYPE tadir-obj_name,
+      lv_size     TYPE i,
+      lv_name     TYPE string,
+      lt_w3params TYPE STANDARD TABLE OF wwwparams,
+      lt_w3mime   TYPE STANDARD TABLE OF w3mime,
+      lt_w3html   TYPE STANDARD TABLE OF w3html.
+
+    lv_obj_name = get_next_objid( ).
+
+    DATA(ls_key) = VALUE wwwdatatab(
+                     relid    = 'MI'
+                     objid    = lv_obj_name
+                     text     = iv_log_object
+                     tdate    = sy-datum
+                     ttime    = sy-uzeit
+                     chname   = sy-uname
+                     devclass = co_package ).
+
+    IF is_data IS INITIAL.
+      lv_xstring = zcl_abapgit_convert=>string_to_xstring_utf8( stringify( it_data ) ).
+    ELSE.
+      lv_xstring = zcl_abapgit_convert=>string_to_xstring_utf8( stringify( is_data ) ).
+    ENDIF.
+
+    CALL FUNCTION 'SCMS_XSTRING_TO_BINARY'
+      EXPORTING
+        buffer        = lv_xstring
+      IMPORTING
+        output_length = lv_size
+      TABLES
+        binary_tab    = lt_w3mime.
+
+    lt_w3params = set_params(
+      is_key    = ls_key
+      iv_size   = lv_size
+      iv_name   = iv_log_object ).
+
+    CALL FUNCTION 'WWWPARAMS_UPDATE'
+      TABLES
+        params       = lt_w3params
+      EXCEPTIONS
+        update_error = 1
+        OTHERS       = 2.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( 'Cannot update W3MI params' ).
+    ENDIF.
+
+    CALL FUNCTION 'WWWDATA_EXPORT'
+      EXPORTING
+        key               = ls_key
+      TABLES
+        mime              = lt_w3mime
+        html              = lt_w3html
+      EXCEPTIONS
+        wrong_object_type = 1
+        export_error      = 2
+        OTHERS            = 3.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( 'Cannot upload W3MI data' ).
+    ENDIF.
+
+    CALL FUNCTION 'TR_TADIR_INTERFACE'
+      EXPORTING
+        wi_tadir_pgmid                 = 'R3TR'
+        wi_tadir_object                = 'W3MI'
+        wi_tadir_obj_name              = lv_obj_name
+        wi_tadir_devclass              = co_package
+        wi_test_modus                  = space
+      EXCEPTIONS
+        tadir_entry_not_existing       = 1
+        tadir_entry_ill_type           = 2
+        no_systemname                  = 3
+        no_systemtype                  = 4
+        original_system_conflict       = 5
+        object_reserved_for_devclass   = 6
+        object_exists_global           = 7
+        object_exists_local            = 8
+        object_is_distributed          = 9
+        obj_specification_not_unique   = 10
+        no_authorization_to_delete     = 11
+        devclass_not_existing          = 12
+        simultanious_set_remove_repair = 13
+        order_missing                  = 14
+        no_modification_of_head_syst   = 15
+        pgmid_object_not_allowed       = 16
+        masterlanguage_not_specified   = 17
+        devclass_not_specified         = 18
+        specify_owner_unique           = 19
+        loc_priv_objs_no_repair        = 20
+        gtadir_not_reached             = 21
+        object_locked_for_order        = 22
+        change_of_class_not_allowed    = 23
+        no_change_from_sap_to_tmp      = 24
+        OTHERS                         = 99.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( 'Cannot update TADIR for W3MI' ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD drop_all.
+
+    DATA:
+      lv_obj_name TYPE tadir-obj_name,
+      lt_tadir    TYPE STANDARD TABLE OF tadir WITH DEFAULT KEY.
+
+    lv_obj_name = co_prefix && '%'.
+
+    SELECT * FROM tadir INTO TABLE @lt_tadir
+      WHERE pgmid = 'R3TR' AND object = 'W3MI' AND obj_name LIKE @lv_obj_name AND devclass = @co_package
+      ORDER BY PRIMARY KEY.
+
+    LOOP AT lt_tadir INTO DATA(ls_tadir).
+
+      DATA(ls_key) = VALUE wwwdatatab(
+                       relid    = 'MI'
+                       objid    = ls_tadir-obj_name
+                       devclass = co_package ).
+
+      CALL FUNCTION 'WWWDATA_DELETE'
+        EXPORTING
+          key               = ls_key
+        EXCEPTIONS
+          wrong_object_type = 1
+          delete_error      = 2
+          OTHERS            = 3.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( 'Cannot delete W3MI data' ).
+      ENDIF.
+
+      CALL FUNCTION 'WWWPARAMS_DELETE_ALL'
+        EXPORTING
+          key          = ls_key
+        EXCEPTIONS
+          delete_error = 1
+          OTHERS       = 2.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( 'Cannot delete W3MI params' ).
+      ENDIF.
+
+      CALL FUNCTION 'TR_TADIR_INTERFACE'
+        EXPORTING
+          wi_delete_tadir_entry          = abap_true
+          wi_tadir_pgmid                 = ls_tadir-pgmid
+          wi_tadir_object                = ls_tadir-object
+          wi_tadir_obj_name              = ls_tadir-obj_name
+          wi_tadir_devclass              = ls_tadir-devclass
+          wi_test_modus                  = space
+        EXCEPTIONS
+          tadir_entry_not_existing       = 1
+          tadir_entry_ill_type           = 2
+          no_systemname                  = 3
+          no_systemtype                  = 4
+          original_system_conflict       = 5
+          object_reserved_for_devclass   = 6
+          object_exists_global           = 7
+          object_exists_local            = 8
+          object_is_distributed          = 9
+          obj_specification_not_unique   = 10
+          no_authorization_to_delete     = 11
+          devclass_not_existing          = 12
+          simultanious_set_remove_repair = 13
+          order_missing                  = 14
+          no_modification_of_head_syst   = 15
+          pgmid_object_not_allowed       = 16
+          masterlanguage_not_specified   = 17
+          devclass_not_specified         = 18
+          specify_owner_unique           = 19
+          loc_priv_objs_no_repair        = 20
+          gtadir_not_reached             = 21
+          object_locked_for_order        = 22
+          change_of_class_not_allowed    = 23
+          no_change_from_sap_to_tmp      = 24
+          OTHERS                         = 99.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( 'Cannot delete TADIR for W3MI' ).
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD get_next_objid.
+
+    DATA:
+      lv_obj_name TYPE tadir-obj_name,
+      lv_counter  TYPE n LENGTH 10.
+
+    " Format: ZABAPGIT_CI_nnnnnnnnnn
+    lv_obj_name = co_prefix && '%'.
+
+    SELECT MAX( obj_name ) FROM tadir INTO @lv_obj_name
+      WHERE pgmid = 'R3TR' AND object = 'W3MI' AND obj_name LIKE @lv_obj_name AND devclass = @co_package.
+    IF sy-subrc = 0.
+      DATA(lv_len) = strlen( co_prefix ).
+      lv_counter = lv_obj_name+lv_len(*).
+    ENDIF.
+
+    lv_counter = lv_counter + 1.
+
+    rv_objid = co_prefix && lv_counter.
+
+  ENDMETHOD.
+
+
+  METHOD set_params.
+
+    DATA ls_param LIKE LINE OF rt_params.
+
+    ls_param-relid = is_key-relid.
+    ls_param-objid = is_key-objid.
+    ls_param-name  = co_param_names-version.
+    ls_param-value = '00001'.
+    INSERT ls_param INTO TABLE rt_params.
+    ls_param-name  = co_param_names-filename.
+    ls_param-value = iv_name.
+    INSERT ls_param INTO TABLE rt_params.
+    ls_param-name  = co_param_names-fileext.
+    ls_param-value = '.json'.
+    INSERT ls_param INTO TABLE rt_params.
+    ls_param-name  = co_param_names-filesize.
+    ls_param-value = iv_size.
+    ls_param-value = condense( ls_param-value ).
+    INSERT ls_param INTO TABLE rt_params.
+    ls_param-name  = co_param_names-mimetype.
+    ls_param-value = 'application/json'.
+    INSERT ls_param INTO TABLE rt_params.
+
+  ENDMETHOD.
+
+
+  METHOD stringify.
+
+    DATA li_json TYPE REF TO zif_abapgit_ajson.
+
+    TRY.
+        li_json = zcl_abapgit_ajson=>create_empty( ).
+        li_json->keep_item_order( ).
+        li_json->set(
+          iv_path = '/'
+          iv_val  = ig_data ).
+        rv_string = li_json->stringify( 2 ).
+      CATCH zcx_abapgit_ajson_error INTO DATA(lx_error).
+        zcx_abapgit_exception=>raise( 'Error converting data to JSON:' && lx_error->get_text( ) ).
+    ENDTRY.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_abapgit_ci_log.clas.abap
+++ b/src/zcl_abapgit_ci_log.clas.abap
@@ -8,7 +8,7 @@ CLASS zcl_abapgit_ci_log DEFINITION
     CONSTANTS:
       co_package TYPE devclass VALUE '$TMP',
       co_prefix  TYPE string VALUE 'ZABAPGIT_CI_',
-      co_all     TYPE string VALUE 'ZABAPGIT_CI_*'.
+      co_all     TYPE string VALUE 'ZABAPGIT_CI_%'.
 
     METHODS add
       IMPORTING

--- a/src/zcl_abapgit_ci_log.clas.abap
+++ b/src/zcl_abapgit_ci_log.clas.abap
@@ -5,6 +5,11 @@ CLASS zcl_abapgit_ci_log DEFINITION
 
   PUBLIC SECTION.
 
+    CONSTANTS:
+      co_package TYPE devclass VALUE '$TMP',
+      co_prefix  TYPE string VALUE 'ZABAPGIT_CI_',
+      co_all     TYPE string VALUE 'ZABAPGIT_CI_*'.
+
     METHODS add
       IMPORTING
         !iv_log_object TYPE string
@@ -26,8 +31,6 @@ CLASS zcl_abapgit_ci_log DEFINITION
       ty_wwwparams_tt TYPE STANDARD TABLE OF wwwparams WITH DEFAULT KEY.
 
     CONSTANTS:
-      co_package TYPE devclass VALUE '$TMP',
-      co_prefix  TYPE string VALUE 'ZABAPGIT_CI_',
       BEGIN OF co_param_names,
         version  TYPE w3_name VALUE 'version',
         fileext  TYPE w3_name VALUE 'fileextension',
@@ -176,10 +179,8 @@ CLASS zcl_abapgit_ci_log IMPLEMENTATION.
       lv_obj_name TYPE tadir-obj_name,
       lt_tadir    TYPE STANDARD TABLE OF tadir WITH DEFAULT KEY.
 
-    lv_obj_name = co_prefix && '%'.
-
     SELECT * FROM tadir INTO TABLE @lt_tadir
-      WHERE pgmid = 'R3TR' AND object = 'W3MI' AND obj_name LIKE @lv_obj_name AND devclass = @co_package
+      WHERE pgmid = 'R3TR' AND object = 'W3MI' AND obj_name LIKE @co_all AND devclass = @co_package
       ORDER BY PRIMARY KEY.
 
     LOOP AT lt_tadir INTO DATA(ls_tadir).
@@ -259,11 +260,8 @@ CLASS zcl_abapgit_ci_log IMPLEMENTATION.
       lv_obj_name TYPE tadir-obj_name,
       lv_counter  TYPE n LENGTH 10.
 
-    " Format: ZABAPGIT_CI_nnnnnnnnnn
-    lv_obj_name = co_prefix && '%'.
-
     SELECT MAX( obj_name ) FROM tadir INTO @lv_obj_name
-      WHERE pgmid = 'R3TR' AND object = 'W3MI' AND obj_name LIKE @lv_obj_name AND devclass = @co_package.
+      WHERE pgmid = 'R3TR' AND object = 'W3MI' AND obj_name LIKE @co_all AND devclass = @co_package.
     IF sy-subrc = 0.
       DATA(lv_len) = strlen( co_prefix ).
       lv_counter = lv_obj_name+lv_len(*).
@@ -271,6 +269,7 @@ CLASS zcl_abapgit_ci_log IMPLEMENTATION.
 
     lv_counter = lv_counter + 1.
 
+    " Format: ZABAPGIT_CI_nnnnnnnnnn
     rv_objid = co_prefix && lv_counter.
 
   ENDMETHOD.

--- a/src/zcl_abapgit_ci_log.clas.xml
+++ b/src/zcl_abapgit_ci_log.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_CI_LOG</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit CI: Log</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
In case of errors related to diffs or transports, the CI process will now log details. This is especially helpful when running CI tests in background. 

![image](https://user-images.githubusercontent.com/59966492/161543772-5b86b620-6d7f-4853-b508-202b95386f08.png)

The logged data can be viewed using transaction `SMW0` or using https://github.com/larshp/mime_editor for package `$TMP` and objects `ZABAPGIT_CI_*`.

![image](https://user-images.githubusercontent.com/59966492/161543723-3ba930c7-1453-46f5-aed4-7f3e3fa0c900.png)

You can clean-up logs as well (after your analysis):

![image](https://user-images.githubusercontent.com/59966492/161543998-e7e56615-c317-41e4-8e05-9961a21dc145.png)
