### PR TITLE
New feature: Check if objects exist before pull

### DIFF
--- a/src/zcl_abapgit_ci_repo.clas.abap
+++ b/src/zcl_abapgit_ci_repo.clas.abap
@@ -535,7 +535,9 @@ CLASS zcl_abapgit_ci_repo IMPLEMENTATION.
 
     cs_ri_repo-pull = zif_abapgit_ci_definitions=>co_status-not_ok.
 
-    DATA(ls_checks) = zcl_abapgit_ci_repo_check=>get( io_repo ).
+    DATA(ls_checks) = zcl_abapgit_ci_repo_check=>get(
+                        io_repo         = io_repo
+                        iv_check_exists = abap_true ).
 
     ls_checks-transport-transport = iv_transport.
 

--- a/src/zcl_abapgit_ci_repo_check.clas.abap
+++ b/src/zcl_abapgit_ci_repo_check.clas.abap
@@ -8,6 +8,7 @@ CLASS zcl_abapgit_ci_repo_check DEFINITION
     CLASS-METHODS get
       IMPORTING
         !io_repo         TYPE REF TO zcl_abapgit_repo_online
+        !iv_check_exists TYPE abap_bool DEFAULT abap_false
       RETURNING
         VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
       RAISING
@@ -15,11 +16,51 @@ CLASS zcl_abapgit_ci_repo_check DEFINITION
         zcx_abapgit_exception .
   PROTECTED SECTION.
   PRIVATE SECTION.
+    CLASS-METHODS check_exists
+      IMPORTING
+        iv_devclass TYPE devclass
+        io_dot      TYPE REF TO zcl_abapgit_dot_abapgit
+        it_files    TYPE zif_abapgit_definitions=>ty_files_tt
+      RAISING
+        zcx_abapgit_exception .
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_CI_REPO_CHECK IMPLEMENTATION.
+CLASS zcl_abapgit_ci_repo_check IMPLEMENTATION.
+
+
+  METHOD check_exists.
+
+    DATA:
+      ls_item    TYPE zif_abapgit_definitions=>ty_item,
+      lv_is_xml  TYPE abap_bool,
+      lv_is_json TYPE abap_bool.
+
+    LOOP AT it_files ASSIGNING FIELD-SYMBOL(<ls_file>) WHERE sha1 IS NOT INITIAL.
+
+      zcl_abapgit_filename_logic=>file_to_object(
+        EXPORTING
+          iv_filename = <ls_file>-filename
+          iv_path     = <ls_file>-path
+          io_dot      = io_dot
+          iv_devclass = iv_devclass
+        IMPORTING
+          es_item     = ls_item
+          ev_is_xml   = lv_is_xml
+          ev_is_json  = lv_is_json ).
+
+      CHECK lv_is_xml = abap_true OR lv_is_json = abap_true. " only object definitions
+
+      CHECK ls_item-obj_type <> 'DEVC' OR ls_item-obj_name <> iv_devclass. " skip the root package
+
+      IF zcl_abapgit_objects=>exists( ls_item ) = abap_true.
+        zcx_abapgit_exception=>raise( |Object { ls_item-obj_type } { ls_item-obj_name } already exists| ).
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
 
 
   METHOD get.
@@ -60,6 +101,14 @@ CLASS ZCL_ABAPGIT_CI_REPO_CHECK IMPLEMENTATION.
                  filename = 'package.devc.xml'.
     IF sy-subrc <> 0.
       zcx_abapgit_cancel=>raise( 'No files found to deserialize' ).
+    ENDIF.
+
+    " Check if any item already exits
+    IF iv_check_exists = abap_true.
+      check_exists(
+        iv_devclass = io_repo->get_package( )
+        io_dot      = lo_dot
+        it_files    = lt_files ).
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
Tests can easily fail or lead in incorrect conclusions if an object already exists before a repo is deserialized.

A new check is introduced as part of the pull phase that checks if any object included in the repo exists already.