### PR TITLE
Support test cases with namespaces

### DIFF
--- a/src/zabapgit_ci_cleanup.prog.abap
+++ b/src/zabapgit_ci_cleanup.prog.abap
@@ -1148,7 +1148,8 @@ ENDCLASS.
 
 INITIALIZATION.
   s_pack[] = VALUE #( ( sign = 'I' option = 'CP' low = 'Z___*' )
-                      ( sign = 'I' option = 'CP' low = '$___*' ) ).
+                      ( sign = 'I' option = 'CP' low = '$___*' )
+                      ( sign = 'I' option = 'CP' low = '/ABAPGIT/_*' ) ).
 
 AT LINE-SELECTION.
   IF gv_transport IS NOT INITIAL.

--- a/src/zcl_abapgit_ci_repo.clas.abap
+++ b/src/zcl_abapgit_ci_repo.clas.abap
@@ -317,6 +317,9 @@ CLASS zcl_abapgit_ci_repo IMPLEMENTATION.
       " packages on uninstall. Therefore these might still exist from the last run and might not be contained
       " in this transport.
       rv_check = abap_false.
+    ELSEIF is_item-obj_type = 'NSPC'.
+      " Namespaces are created once and not included in the CI transport (unless it's the very first run)
+      rv_check = abap_false.
     ELSEIF is_item-obj_type = 'SICF' AND iv_deletion = abap_true.
       " Object name of ICF services can not be decoded after deletion since this needs the TADIR entry
       rv_check = abap_false.

--- a/src/zcl_abapgit_ci_repo_category.clas.abap
+++ b/src/zcl_abapgit_ci_repo_category.clas.abap
@@ -68,6 +68,8 @@ CLASS zcl_abapgit_ci_repo_category DEFINITION
       c_category_idoc_label   TYPE string VALUE 'IDoc',
       c_category_iac          TYPE string VALUE 'iac',
       c_category_iac_label    TYPE string VALUE 'Internet Application Components',
+      c_category_nspace       TYPE string VALUE 'namespace',
+      c_category_nspace_label TYPE string VALUE 'Namespace',
       c_category_others       TYPE string VALUE 'other',
       c_category_others_label TYPE string VALUE 'Others'.
 
@@ -157,6 +159,11 @@ CLASS zcl_abapgit_ci_repo_category IMPLEMENTATION.
     " Add "Internet Application Components"
     ls_category-category       = c_category_iac.
     ls_category-category_label = c_category_iac_label.
+    INSERT ls_category INTO TABLE rt_result.
+
+    " Add "Namespace"
+    ls_category-category       = c_category_nspace.
+    ls_category-category_label = c_category_nspace_label.
     INSERT ls_category INTO TABLE rt_result.
 
     SORT rt_result BY category_label.
@@ -320,6 +327,8 @@ CLASS zcl_abapgit_ci_repo_category IMPLEMENTATION.
           rv_result = c_category_docs.
         WHEN 'IDOC' OR 'IEXT'.
           rv_result = c_category_idoc.
+        WHEN 'NSPC'.
+          rv_result = c_category_nspace.
         WHEN 'IARP' OR 'IASP' OR 'IATU' OR 'IAXU'.
           rv_result = c_category_iac.
         WHEN OTHERS.

--- a/src/zcl_abapgit_ci_repos.clas.abap
+++ b/src/zcl_abapgit_ci_repos.clas.abap
@@ -6,6 +6,10 @@ CLASS zcl_abapgit_ci_repos DEFINITION
     CONSTANTS:
       gc_default_branch TYPE string VALUE 'refs/heads/main'.
 
+    " Open source namespace used for tests
+    CONSTANTS:
+      gc_namespace TYPE namespace VALUE '/ABAPGIT/'.
+
     CLASS-METHODS:
       update_abapgit_repo
         RAISING
@@ -116,6 +120,7 @@ CLASS zcl_abapgit_ci_repos IMPLEMENTATION.
 
 
   METHOD get_repo_list_with_packages.
+    DATA lv_prefix TYPE namespace.
     FIELD-SYMBOLS: <ls_ci_repo> TYPE zabapgit_ci_result.
 
     " Copy it_repos into rt_repos, creating an entry for local and transportable packages each
@@ -150,10 +155,15 @@ CLASS zcl_abapgit_ci_repos IMPLEMENTATION.
       ENDIF.
 
       IF is_options-check_transportable = abap_true.
+        IF <ls_ci_repo>-name CP 'NSPC*'.
+          lv_prefix = gc_namespace && '_'.
+        ELSE.
+          lv_prefix = 'Z___'.
+        ENDIF.
         INSERT CORRESPONDING #( <ls_repo> )
                INTO TABLE rt_repos
                ASSIGNING <ls_ci_repo>.
-        <ls_ci_repo>-package      = CONV devclass( |Z___{ to_upper( <ls_ci_repo>-name ) }| ).
+        <ls_ci_repo>-package      = CONV devclass( |{ lv_prefix }{ to_upper( <ls_ci_repo>-name ) }| ).
         <ls_ci_repo>-layer        = is_options-layer.
         <ls_ci_repo>-do_not_purge = is_options-no_purge.
         <ls_ci_repo>-logging      = is_options-logging.


### PR DESCRIPTION
Test repositories containing namespaced objects can now be included in CI. The objects must be created in the /ABAPGIT/ namespace.

You can find the namespace keys at:
https://github.com/SAP/abap-open-source-namespaces or create your own at:
https://me.sap.com/namespaces/opensource